### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/preview-netlify.yml
+++ b/.github/workflows/preview-netlify.yml
@@ -1,4 +1,7 @@
 name: Frontend PR Preview (Netlify)
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/C-Elkins/IT-Asset-Management/security/code-scanning/1](https://github.com/C-Elkins/IT-Asset-Management/security/code-scanning/1)

The best fix for this issue is to explicitly add a `permissions:` block to the workflow (either at the job level or, more simply, at the workflow root—above `jobs:`) that limits GITHUB_TOKEN permissions to the minimum required. For this workflow, the steps require permission to read repository contents (`contents: read`) and to write PR comments (`pull-requests: write`).

The change should be made at the root of the file (above or just below the `name:` line, but always above `jobs:`) as recommended for organization-wide workflows, unless more granular job-level permissions are needed. No additional imports or external packages are needed; the change is declarative in the YAML workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
